### PR TITLE
Make "mismatched input" errors a bit more helpful

### DIFF
--- a/runtime/Go/antlr/error_strategy.go
+++ b/runtime/Go/antlr/error_strategy.go
@@ -558,6 +558,8 @@ func (d *DefaultErrorStrategy) GetTokenErrorDisplay(t Token) string {
 		} else {
 			s = "<" + strconv.Itoa(t.GetTokenType()) + ">"
 		}
+	} else {
+		s = fmt.Sprintf("%s <%s>", s, strconv.Itoa(t.GetTokenType()))
 	}
 	return d.escapeWSAndQuote(s)
 }


### PR DESCRIPTION
Currently "mismatched input" errors do not inform the user what lexer token matched on the given token. This is generally useful information when testing (and using) generated parsers.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->